### PR TITLE
Fix ruby style

### DIFF
--- a/lib/minimum/omniauth/scaffold/templates/controllers/top_controller.rb
+++ b/lib/minimum/omniauth/scaffold/templates/controllers/top_controller.rb
@@ -1,6 +1,5 @@
 class TopController < ApplicationController
   skip_before_action :authenticate
 
-  def index
-  end
+  def index; end
 end

--- a/lib/minimum/omniauth/scaffold/version.rb
+++ b/lib/minimum/omniauth/scaffold/version.rb
@@ -1,7 +1,7 @@
 module Minimum
   module Omniauth
     module Scaffold
-      VERSION = '0.4.6'
+      VERSION = '0.4.7'
     end
   end
 end


### PR DESCRIPTION
According to the [ruby style guide](https://github.com/bbatsov/ruby-style-guide#no-single-line-methods), empty method definitions should be put on a single line.
RuboCop also defines [the style for emptymethod](http://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/EmptyMethod)